### PR TITLE
Set up scripted suite with failing test for #2

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,3 +1,5 @@
+libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")

--- a/sbt-scalafmt/build.sbt
+++ b/sbt-scalafmt/build.sbt
@@ -15,3 +15,9 @@ scalacOptions ++= Seq(
   "-deprecation",
   "-feature"
 )
+
+scriptedSettings
+scriptedBufferLog := false
+scriptedLaunchOpts := Seq(
+  "-Dplugin.version=" + version.value
+)

--- a/sbt-scalafmt/src/sbt-test/sbt-scalafmt/oncompile/build.sbt
+++ b/sbt-scalafmt/src/sbt-test/sbt-scalafmt/oncompile/build.sbt
@@ -1,0 +1,3 @@
+lazy val root = (project in file("."))
+  .enablePlugins(ScalafmtPlugin)
+  .settings(scalafmtOnCompile := true)

--- a/sbt-scalafmt/src/sbt-test/sbt-scalafmt/oncompile/project
+++ b/sbt-scalafmt/src/sbt-test/sbt-scalafmt/oncompile/project
@@ -1,0 +1,1 @@
+../simple/project

--- a/sbt-scalafmt/src/sbt-test/sbt-scalafmt/oncompile/src
+++ b/sbt-scalafmt/src/sbt-test/sbt-scalafmt/oncompile/src
@@ -1,0 +1,1 @@
+../simple/src

--- a/sbt-scalafmt/src/sbt-test/sbt-scalafmt/oncompile/test
+++ b/sbt-scalafmt/src/sbt-test/sbt-scalafmt/oncompile/test
@@ -1,0 +1,3 @@
+-> scalafmt::test
+> compile
+> scalafmt::test

--- a/sbt-scalafmt/src/sbt-test/sbt-scalafmt/simple/build.sbt
+++ b/sbt-scalafmt/src/sbt-test/sbt-scalafmt/simple/build.sbt
@@ -1,0 +1,2 @@
+lazy val root = (project in file("."))
+  .enablePlugins(ScalafmtPlugin)

--- a/sbt-scalafmt/src/sbt-test/sbt-scalafmt/simple/project/plugins.sbt
+++ b/sbt-scalafmt/src/sbt-test/sbt-scalafmt/simple/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(v) => addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % v)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/sbt-scalafmt/src/sbt-test/sbt-scalafmt/simple/src/main/scala/hello.scala
+++ b/sbt-scalafmt/src/sbt-test/sbt-scalafmt/simple/src/main/scala/hello.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println( "hello" )
+}

--- a/sbt-scalafmt/src/sbt-test/sbt-scalafmt/simple/test
+++ b/sbt-scalafmt/src/sbt-test/sbt-scalafmt/simple/test
@@ -1,0 +1,3 @@
+-> scalafmt::test
+> scalafmt
+> scalafmt::test


### PR DESCRIPTION
I'm not sure what the resolution to the problem is yet, but when it gets resolved I'd like it not to regress again.

I used the `plugin.version` property pattern that is somewhat conventional from the sbt docs on scripted, but if it's confusing that that gets indirectly set from your property named `build.version` I could change the names to be the same. I'm not familiar with your sbt-cross plugin or your typical workflow for this. With this branch as-is, I've run the scripted tests with:

    sbt -Dbuild.version=0.3 scripted