### PR TITLE
Prevent ScalafmtPlugin from trying to format SBT files in the base directory

### DIFF
--- a/sbt-scalafmt/src/main/scala/com/lucidchart/sbt/scalafmt/ScalafmtPlugin.scala
+++ b/sbt-scalafmt/src/main/scala/com/lucidchart/sbt/scalafmt/ScalafmtPlugin.scala
@@ -16,7 +16,7 @@ object ScalafmtPlugin extends AutoPlugin {
                 Def.task(Seq.empty[File])
               } else if (includeFilter.value == UseScalafmtConfigFilter) {
                 (baseDirectory, scalafmtter)
-                  .map((base, scalafmtter) => (base * new ScalafmtFileFilter(scalafmtter)).get)
+                  .map((base, scalafmtter) => (base * (new ScalafmtFileFilter(scalafmtter) && "*.scala")).get)
               } else {
                 (baseDirectory, includeFilter, excludeFilter).map(
                   (base, include, exclude) => (base * include --- base * exclude).get

--- a/sbt-scalafmt/src/sbt-test/sbt-scalafmt/simple/build.sbt
+++ b/sbt-scalafmt/src/sbt-test/sbt-scalafmt/simple/build.sbt
@@ -1,2 +1,1 @@
-scalafmtOnCompile := true
 ignoreErrors in scalafmt := false


### PR DESCRIPTION
This should fix #31. That issue gives a reproducer with formatting a meta-build, but I found I was able to trigger the error in even simpler projects by just toggling `ignoreErrors` to `false`.

The root problem is that the default `scalafmt` file filter accepts `*.scala` and `*.sbt`, but the `ScalafmtPlugin`'s dialect is hard-coded to just Scala. 3e9b1a7e4b88bb24e0e01b053550c643734ed0e3 changed how `ScalafmtPlugin` finds sources so it could properly pick up Scala files in the project base directory, but it also resulted in SBT files getting pulled into the source list. The bug wasn't caught because `ignoreErrors` defaults to `true`.

Should we take this chance to change the default for `ignoreErrors`?