### PR TITLE
Accept scalafmtVersion 1.x

### DIFF
--- a/sbt-scalafmt/src/main/scala/com/lucidchart/sbt/scalafmt/ScalafmtCorePlugin.scala
+++ b/sbt-scalafmt/src/main/scala/com/lucidchart/sbt/scalafmt/ScalafmtCorePlugin.scala
@@ -240,9 +240,9 @@ object ScalafmtCorePlugin extends AutoPlugin {
     libraryDependencies ++=
       (if (scalafmtUseIvy.value) (libraryDependencies in Scalafmt).value.map(_ % Scalafmt) else Seq.empty),
     libraryDependencies in Scalafmt := {
-      val (scalaBinaryVersion, fmtVersion) = "(\\d+.){0,1}\\d+".r.findPrefixOf(scalafmtVersion.value) match {
-        case Some("0.6")         => ("2.11", "0.6")
-        case Some("0.7" | "1.0") => ("2.12", "1.0")
+      val (scalaBinaryVersion, fmtVersion) = scalafmtVersion.value.split('.') match {
+        case Array("0", "6", _ *)                   => ("2.11", "0.6")
+        case Array("0", "7", _ *) | Array("1", _ *) => ("2.12", "1.0")
         case _ =>
           println(s"Warning: Unknown Scalafmt version ${scalafmtVersion.value}; using 1.0 interface")
           ("2.12", "1.0")

--- a/sbt-scalafmt/src/main/scala/com/lucidchart/sbt/scalafmt/ScalafmtCorePlugin.scala
+++ b/sbt-scalafmt/src/main/scala/com/lucidchart/sbt/scalafmt/ScalafmtCorePlugin.scala
@@ -241,8 +241,8 @@ object ScalafmtCorePlugin extends AutoPlugin {
       (if (scalafmtUseIvy.value) (libraryDependencies in Scalafmt).value.map(_ % Scalafmt) else Seq.empty),
     libraryDependencies in Scalafmt := {
       val (scalaBinaryVersion, fmtVersion) = scalafmtVersion.value.split('.') match {
-        case Array("0", "6", _ *)                   => ("2.11", "0.6")
-        case Array("0", "7", _ *) | Array("1", _ *) => ("2.12", "1.0")
+        case Array("0", "6", _ *)                                               => ("2.11", "0.6")
+        case Array("0", "7", _ *) | Array("1", "0", _ *) | Array("1", "1", _ *) => ("2.12", "1.0")
         case _ =>
           println(s"Warning: Unknown Scalafmt version ${scalafmtVersion.value}; using 1.0 interface")
           ("2.12", "1.0")


### PR DESCRIPTION
Use 1.0 as fmtVersion for 1.x.x. According to [this comment](https://github.com/lucidsoftware/neo-sbt-scalafmt/issues/35#issuecomment-316017173) scalafmt 1.x will keep binary compatibility.

Fixes #35 