### PR TITLE
ScalafmtFileFilter accepts only files

### DIFF
--- a/sbt-scalafmt/src/main/scala/com/lucidchart/sbt/scalafmt/ScalafmtFileFilter.scala
+++ b/sbt-scalafmt/src/main/scala/com/lucidchart/sbt/scalafmt/ScalafmtFileFilter.scala
@@ -5,5 +5,5 @@ import java.io.File
 import sbt.FileFilter
 
 class ScalafmtFileFilter(scalafmtter: Scalafmtter) extends FileFilter {
-  def accept(file: File) = scalafmtter.includeFile(file.toPath)
+  def accept(file: File) = file.isFile && scalafmtter.includeFile(file.toPath)
 }


### PR DESCRIPTION
In default settings, a plugin try to format *.(sbt|scala) directories and throw a exception.
e.g. a .sbt directory existed.