### PR TITLE
sbt versions upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 An sbt plugin for [Scalafmt](http://scalameta.org/scalafmt/) that
 
 * formats .sbt and .scala files
-* supports sbt 0.13 and 1.0.0-RC2
+* supports sbt 0.13 and 1.0.0-RC3
 * supports Scalafmt 0.6 and 1.0
 * runs in-process
 * uses sbt's ivy2 for dependency resolution

--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,7 @@ lazy val sbtVersionAxis = new DefaultAxis {
 }
 
 lazy val `sbt-scalafmt` = project.dependsOn(`scalafmt-api`).cross(sbtVersionAxis)
-lazy val `sbt-scalafmt_0.13` = `sbt-scalafmt`("0.13.15")
+lazy val `sbt-scalafmt_0.13` = `sbt-scalafmt`("0.13.16")
   .settings(scriptedSettings)
   .settings(
     scriptedDependencies := {
@@ -91,5 +91,5 @@ lazy val `sbt-scalafmt_0.13` = `sbt-scalafmt`("0.13.15")
 lazy val `sbt-scalafmt_1.0.0-RC3` = `sbt-scalafmt`("1.0.0-RC3")
 
 lazy val `sbt-scalafmt-coursier` = project.cross(sbtVersionAxis).dependsOn(`sbt-scalafmt`)
-lazy val `sbt-scalafmt-coursier_0.13` = `sbt-scalafmt-coursier`("0.13.15")
+lazy val `sbt-scalafmt-coursier_0.13` = `sbt-scalafmt-coursier`("0.13.16")
 lazy val `sbt-scalafmt-coursier_1.0.0-RC3` = `sbt-scalafmt-coursier`("1.0.0-RC3")

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val `scalafmt-impl` = project
 lazy val `scalafmt-impl-0.6` = `scalafmt-impl`("0.6.8").settings(
   scalaVersion := "2.11.8"
 )
-lazy val `scalafmt-impl-1.0` = `scalafmt-impl`("1.0.0-RC2").settings(
+lazy val `scalafmt-impl-1.0` = `scalafmt-impl`("1.0.0-RC3").settings(
   scalaVersion := "2.12.2"
 )
 
@@ -88,8 +88,8 @@ lazy val `sbt-scalafmt_0.13` = `sbt-scalafmt`("0.13.15")
     },
     scriptedLaunchOpts += s"-Dplugin.version=${version.value}"
   )
-lazy val `sbt-scalafmt_1.0.0-RC2` = `sbt-scalafmt`("1.0.0-RC2")
+lazy val `sbt-scalafmt_1.0.0-RC3` = `sbt-scalafmt`("1.0.0-RC3")
 
 lazy val `sbt-scalafmt-coursier` = project.cross(sbtVersionAxis).dependsOn(`sbt-scalafmt`)
 lazy val `sbt-scalafmt-coursier_0.13` = `sbt-scalafmt-coursier`("0.13.15")
-lazy val `sbt-scalafmt-coursier_1.0.0-RC2` = `sbt-scalafmt-coursier`("1.0.0-RC2")
+lazy val `sbt-scalafmt-coursier_1.0.0-RC3` = `sbt-scalafmt-coursier`("1.0.0-RC3")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/sbt-scalafmt/src/sbt-test/sbt-scalafmt/oncompile/project/build.properties
+++ b/sbt-scalafmt/src/sbt-test/sbt-scalafmt/oncompile/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/sbt-scalafmt/src/sbt-test/sbt-scalafmt/simple/project/build.properties
+++ b/sbt-scalafmt/src/sbt-test/sbt-scalafmt/simple/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16


### PR DESCRIPTION
Upgrades to sbt 0.13.16 for build and tests; upgrade to 1.0.0-RC3 for cross build