### PR TITLE
Replace <input> in error messages when not ignoring errors.

### DIFF
--- a/sbt-scalafmt/src/main/scala/com/lucidchart/sbt/scalafmt/ScalafmtCorePlugin.scala
+++ b/sbt-scalafmt/src/main/scala/com/lucidchart/sbt/scalafmt/ScalafmtCorePlugin.scala
@@ -54,15 +54,19 @@ object ScalafmtCorePlugin extends AutoPlugin {
         {
           try scalafmtter(input)
           catch {
-            case NonFatal(e) if ignoreErrors =>
+            case NonFatal(e) =>
               val exceptionMesssage = e.getLocalizedMessage
               val message = if (exceptionMesssage.contains("<input>")) {
                 exceptionMesssage.replace("<input>", name)
               } else {
                 s"$name:\n$exceptionMesssage"
               }
-              logger.warn(message)
-              input
+              if (ignoreErrors) {
+                logger.warn(message)
+                input
+              } else {
+                throw new Exception(message, e)
+              }
           }
         }
     }


### PR DESCRIPTION
Currently when scalafmt hits a parsing error the message that ends up getting displayed shows `<input>` as the file name, which isn't very helpful for debugging. I found that logic already exists in the plugin for swapping out `<input>` with the actual file name, but it's gated behind the `ignoreErrors` flag.

This change causes the file name to be swapped into the error message even when errors are not being ignored.