### PR TITLE
Cache formatters, fixes #54

### DIFF
--- a/sbt-scalafmt/src/main/scala/com/lucidchart/sbt/scalafmt/ScalafmtCorePlugin.scala
+++ b/sbt-scalafmt/src/main/scala/com/lucidchart/sbt/scalafmt/ScalafmtCorePlugin.scala
@@ -251,8 +251,8 @@ object ScalafmtCorePlugin extends AutoPlugin {
       (if (scalafmtUseIvy.value) (libraryDependencies in Scalafmt).value.map(_ % Scalafmt) else Seq.empty),
     libraryDependencies in Scalafmt := {
       val (scalaBinaryVersion, fmtVersion) = "(\\d+.){0,1}\\d+".r.findPrefixOf(scalafmtVersion.value) match {
-        case Some("0.6")                 => ("2.11", "0.6")
-        case Some("0.7" | "1.0" | "1.1"| "1.2") => ("2.12", "1.0")
+        case Some("0.6")                         => ("2.11", "0.6")
+        case Some("0.7" | "1.0" | "1.1" | "1.2") => ("2.12", "1.0")
         case _ =>
           println(s"Warning: Unknown Scalafmt version ${scalafmtVersion.value}; using 1.0 interface")
           ("2.12", "1.0")

--- a/scalafmt-api/src/main/java/com/lucidchart/scalafmt/api/LRUCache.java
+++ b/scalafmt-api/src/main/java/com/lucidchart/scalafmt/api/LRUCache.java
@@ -5,12 +5,15 @@ import java.util.Map;
 
 /**
  * A very simple LRU cache based an a JVM collection type.
+ *
+ * http://chriswu.me/blog/a-lru-cache-in-10-lines-of-java/
  */
 
 public class LRUCache<K, V> extends LinkedHashMap<K, V> {
     private int cacheSize;
 
     public LRUCache(int cacheSize) {
+        // Magic happens here: the third parameter specifies that the keys are ordered on access not insertion.
         super(16, 0.75f, true);
         this.cacheSize = cacheSize;
     }

--- a/scalafmt-api/src/main/java/com/lucidchart/scalafmt/api/LRUCache.java
+++ b/scalafmt-api/src/main/java/com/lucidchart/scalafmt/api/LRUCache.java
@@ -1,0 +1,21 @@
+package com.lucidchart.scalafmt.api;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A very simple LRU cache based an a JVM collection type.
+ */
+
+public class LRUCache<K, V> extends LinkedHashMap<K, V> {
+    private int cacheSize;
+
+    public LRUCache(int cacheSize) {
+        super(16, 0.75f, true);
+        this.cacheSize = cacheSize;
+    }
+
+    protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+        return size() >= cacheSize;
+    }
+}

--- a/scalafmt-impl/src/scalafmt-0.6/main/scala/com/lucidchart/scalafmt/impl/ScalafmtFactory.scala
+++ b/scalafmt-impl/src/scalafmt-0.6/main/scala/com/lucidchart/scalafmt/impl/ScalafmtFactory.scala
@@ -1,18 +1,9 @@
 package com.lucidchart.scalafmt.impl
 
-import com.lucidchart.scalafmt.api
-import com.lucidchart.scalafmt.api.LRUCache
 import org.scalafmt.config.Config
 
-final class ScalafmtFactory extends api.ScalafmtFactory {
+final class ScalafmtFactory extends CachingScalafmtFactory {
 
-  private val cachedFormatters = new LRUCache[String, Scalafmtter](100)
-
-  def fromConfig(configString: String) = {
-    Option(cachedFormatters.get(configString)).getOrElse {
-      val formatter = new Scalafmtter(Config.fromHocon(configString, Option.empty).right.get)
-      cachedFormatters.put(configString, formatter)
-    }
-  }
-
+  override def buildScalafmtterFromConfig(configString: String) =
+    new Scalafmtter(Config.fromHocon(configString, Option.empty).right.get)
 }

--- a/scalafmt-impl/src/scalafmt-0.6/main/scala/com/lucidchart/scalafmt/impl/ScalafmtFactory.scala
+++ b/scalafmt-impl/src/scalafmt-0.6/main/scala/com/lucidchart/scalafmt/impl/ScalafmtFactory.scala
@@ -1,13 +1,18 @@
 package com.lucidchart.scalafmt.impl
 
 import com.lucidchart.scalafmt.api
-import com.lucidchart.scalafmt.api.{Dialect, Scalafmtter}
-import java.util.function
+import com.lucidchart.scalafmt.api.LRUCache
 import org.scalafmt.config.Config
-import scala.meta.dialects
 
 final class ScalafmtFactory extends api.ScalafmtFactory {
 
-  def fromConfig(configString: String) = new Scalafmtter(Config.fromHocon(configString, Option.empty).right.get)
+  private val cachedFormatters = new LRUCache[String, Scalafmtter](100)
+
+  def fromConfig(configString: String) = {
+    Option(cachedFormatters.get(configString)).getOrElse {
+      val formatter = new Scalafmtter(Config.fromHocon(configString, Option.empty).right.get)
+      cachedFormatters.put(configString, formatter)
+    }
+  }
 
 }

--- a/scalafmt-impl/src/scalafmt-1.0/main/scala/com/lucidchart/scalafmt/impl/ScalafmtFactory.scala
+++ b/scalafmt-impl/src/scalafmt-1.0/main/scala/com/lucidchart/scalafmt/impl/ScalafmtFactory.scala
@@ -1,21 +1,13 @@
 package com.lucidchart.scalafmt.impl
 
 import com.lucidchart.scalafmt.api
-import com.lucidchart.scalafmt.api.{Dialect, Scalafmtter}
-import com.lucidchart.scalafmt.api.LRUCache
 import java.util.function
 import org.scalafmt.config.Config
 import scala.meta.dialects
 
-final class ScalafmtFactory extends api.ScalafmtFactory {
+final class ScalafmtFactory extends CachingScalafmtFactory {
 
-  private val cachedFormatters = new LRUCache[String, Scalafmtter](100)
-
-  def fromConfig(configString: String) = {
-    Option(cachedFormatters.get(configString)).getOrElse {
-      val formatter = new Scalafmtter(Config.fromHocon(configString, Option.empty).right.get)
-      cachedFormatters.put(configString, formatter)
-    }
-  }
+  override def buildScalafmtterFromConfig(configString: String) =
+    new Scalafmtter(Config.fromHoconString(configString, Option.empty).get)
 
 }

--- a/scalafmt-impl/src/scalafmt-1.0/main/scala/com/lucidchart/scalafmt/impl/ScalafmtFactory.scala
+++ b/scalafmt-impl/src/scalafmt-1.0/main/scala/com/lucidchart/scalafmt/impl/ScalafmtFactory.scala
@@ -2,15 +2,10 @@ package com.lucidchart.scalafmt.impl
 
 import com.lucidchart.scalafmt.api
 import com.lucidchart.scalafmt.api.{Dialect, Scalafmtter}
+import com.lucidchart.scalafmt.api.LRUCache
 import java.util.function
 import org.scalafmt.config.Config
 import scala.meta.dialects
-
-package com.lucidchart.scalafmt.impl
-
-import com.lucidchart.scalafmt.api
-import com.lucidchart.scalafmt.api.LRUCache
-import org.scalafmt.config.Config
 
 final class ScalafmtFactory extends api.ScalafmtFactory {
 

--- a/scalafmt-impl/src/scalafmt-1.0/main/scala/com/lucidchart/scalafmt/impl/ScalafmtFactory.scala
+++ b/scalafmt-impl/src/scalafmt-1.0/main/scala/com/lucidchart/scalafmt/impl/ScalafmtFactory.scala
@@ -6,8 +6,21 @@ import java.util.function
 import org.scalafmt.config.Config
 import scala.meta.dialects
 
+package com.lucidchart.scalafmt.impl
+
+import com.lucidchart.scalafmt.api
+import com.lucidchart.scalafmt.api.LRUCache
+import org.scalafmt.config.Config
+
 final class ScalafmtFactory extends api.ScalafmtFactory {
 
-  def fromConfig(configString: String) = new Scalafmtter(Config.fromHoconString(configString, Option.empty).get)
+  private val cachedFormatters = new LRUCache[String, Scalafmtter](100)
+
+  def fromConfig(configString: String) = {
+    Option(cachedFormatters.get(configString)).getOrElse {
+      val formatter = new Scalafmtter(Config.fromHocon(configString, Option.empty).right.get)
+      cachedFormatters.put(configString, formatter)
+    }
+  }
 
 }

--- a/scalafmt-impl/src/shared/main/java/com/lucidchart/scalafmt/impl/LRUCache.java
+++ b/scalafmt-impl/src/shared/main/java/com/lucidchart/scalafmt/impl/LRUCache.java
@@ -1,4 +1,4 @@
-package com.lucidchart.scalafmt.api;
+package com.lucidchart.scalafmt.impl;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -13,7 +13,7 @@ public class LRUCache<K, V> extends LinkedHashMap<K, V> {
     private int cacheSize;
 
     public LRUCache(int cacheSize) {
-        // Magic happens here: the third parameter specifies that the keys are ordered on access not insertion.
+        // Magic happens here: the third parameter specifies that the keys are ordered by access not insertion.
         super(16, 0.75f, true);
         this.cacheSize = cacheSize;
     }

--- a/scalafmt-impl/src/shared/main/scala/com/lucidchart/scalafmt/impl/CachingScalafmtFactory.scala
+++ b/scalafmt-impl/src/shared/main/scala/com/lucidchart/scalafmt/impl/CachingScalafmtFactory.scala
@@ -12,5 +12,6 @@ trait CachingScalafmtFactory extends api.ScalafmtFactory {
     Option(cachedFormatters.get(configString)).getOrElse {
       val formatter = buildScalafmtterFromConfig(configString)
       cachedFormatters.put(configString, formatter)
+      formatter
     }
 }

--- a/scalafmt-impl/src/shared/main/scala/com/lucidchart/scalafmt/impl/CachingScalafmtFactory.scala
+++ b/scalafmt-impl/src/shared/main/scala/com/lucidchart/scalafmt/impl/CachingScalafmtFactory.scala
@@ -1,18 +1,16 @@
 package com.lucidchart.scalafmt.impl
 
 import com.lucidchart.scalafmt.api
-import com.lucidchart.scalafmt.api.LRUCache
 
-trait CachingScalafmtFactory extends api.ScalafmtFactory{
+trait CachingScalafmtFactory extends api.ScalafmtFactory {
 
   private val cachedFormatters = new LRUCache[String, Scalafmtter](256)
 
   def buildScalafmtterFromConfig(configString: String): Scalafmtter
 
-  override def fromConfig(configString: String): api.Scalafmtter = {
+  override def fromConfig(configString: String): api.Scalafmtter =
     Option(cachedFormatters.get(configString)).getOrElse {
       val formatter = buildScalafmtterFromConfig(configString)
       cachedFormatters.put(configString, formatter)
     }
-  }
 }

--- a/scalafmt-impl/src/shared/main/scala/com/lucidchart/scalafmt/impl/CachingScalafmtFactory.scala
+++ b/scalafmt-impl/src/shared/main/scala/com/lucidchart/scalafmt/impl/CachingScalafmtFactory.scala
@@ -1,0 +1,18 @@
+package com.lucidchart.scalafmt.impl
+
+import com.lucidchart.scalafmt.api
+import com.lucidchart.scalafmt.api.LRUCache
+
+trait CachingScalafmtFactory extends api.ScalafmtFactory{
+
+  private val cachedFormatters = new LRUCache[String, Scalafmtter](256)
+
+  def buildScalafmtterFromConfig(configString: String): Scalafmtter
+
+  override def fromConfig(configString: String): api.Scalafmtter = {
+    Option(cachedFormatters.get(configString)).getOrElse {
+      val formatter = buildScalafmtterFromConfig(configString)
+      cachedFormatters.put(configString, formatter)
+    }
+  }
+}


### PR DESCRIPTION
This PR caches the Scalafmtters as it turns out that instantiating them is expensive (#54).

I decided to use a very simple LRU cache based on a Java collection type because I didn't want to import either Guava (too big) or sbt-util-cache (seems file based, not clear if available for sbt 0.13).